### PR TITLE
Fix due date handling

### DIFF
--- a/src/TaskParser.ts
+++ b/src/TaskParser.ts
@@ -57,7 +57,7 @@ export class TaskRegex {
   static readonly hashTags = /(^|\s)#[^ !@#$%^&*(),.?":{}|<>]+/g;
   
   // Date related regular expressions - matches emoji followed by date
-  static readonly dueDateRegex = /🗓️\s?(\d{4}-\d{2}-\d{2})/;
+  static readonly dueDateRegex = /[📅🗓️]\s?(\d{4}-\d{2}-\d{2})/;
   static readonly scheduledDateRegex = /⏳\s?(\d{4}-\d{2}-\d{2})/;
   static readonly startDateRegex = /🛫\s?(\d{4}-\d{2}-\d{2})/;
   static readonly createdDateRegex = /➕\s?(\d{4}-\d{2}-\d{2})/;

--- a/tests/task-extraction.test.ts
+++ b/tests/task-extraction.test.ts
@@ -29,7 +29,7 @@ describe('Task Extraction', () => {
     
     // Check incomplete tasks
     const incompleteTasks = tasks.filter(task => task.status === 'incomplete');
-    expect(incompleteTasks.length).toBe(13);
+    expect(incompleteTasks.length).toBe(14);
     
     // Check complete tasks
     const completeTasks = tasks.filter(task => task.status === 'complete');

--- a/tests/task-extraction.test.ts
+++ b/tests/task-extraction.test.ts
@@ -25,7 +25,7 @@ describe('Task Extraction', () => {
     const tasks = await extractTasksFromFile(sampleTasksPath);
     
     // Should find the right number of tasks
-    expect(tasks.length).toBe(17); // Total tasks in sample-tasks.md
+    expect(tasks.length).toBe(18); // Total tasks in sample-tasks.md
     
     // Check incomplete tasks
     const incompleteTasks = tasks.filter(task => task.status === 'incomplete');

--- a/tests/task-parsing.test.ts
+++ b/tests/task-parsing.test.ts
@@ -53,7 +53,7 @@ describe('Task Parsing and Filtering', () => {
     
     // Test not done filter
     const notDoneResults = tasks.filter(task => applyFilter(task, 'not done'));
-    expect(notDoneResults.length).toBe(5);
+    expect(notDoneResults.length).toBe(6);
     expect(notDoneResults.every(task => task.status === 'incomplete')).toBe(true);
   });
   
@@ -104,7 +104,7 @@ describe('Task Parsing and Filtering', () => {
     path includes file1`;
     
     const result = queryTasks(tasks, multiFilterQuery);
-    expect(result.length).toBe(4);
+    expect(result.length).toBe(5);
     expect(result.every(task => 
       task.status === 'incomplete' && task.filePath.includes('file1')
     )).toBe(true);

--- a/tests/task-parsing.test.ts
+++ b/tests/task-parsing.test.ts
@@ -23,7 +23,7 @@ describe('Task Parsing and Filtering', () => {
   
   test('parseTaskLine should parse tasks correctly', () => {
     // Check that we parsed the expected number of tasks
-    expect(tasks.length).toBe(6);
+    expect(tasks.length).toBe(7);
     
     // Check that task properties are set correctly
     expect(tasks[0].description).toBe('Basic task');
@@ -37,9 +37,12 @@ describe('Task Parsing and Filtering', () => {
     
     // Task with due date
     expect(tasks[3].dueDate).toBe('2025-04-18');
+
+     // Task with due date
+    expect(tasks[4].dueDate).toBe('2025-04-18');
     
     // Completed task
-    expect(tasks[4].status).toBe('complete');
+    expect(tasks[5].status).toBe('complete');
   });
   
   test('applyFilter should filter tasks by done status', () => {

--- a/tests/task-parsing.test.ts
+++ b/tests/task-parsing.test.ts
@@ -86,7 +86,7 @@ describe('Task Parsing and Filtering', () => {
     const notDescriptionResults = tasks.filter(task => 
       applyFilter(task, 'description does not include priority')
     );
-    expect(notDescriptionResults.length).toBe(5);
+    expect(notDescriptionResults.length).toBe(6);
     expect(notDescriptionResults.every(task => !task.description.includes('priority'))).toBe(true);
   });
   
@@ -96,7 +96,7 @@ describe('Task Parsing and Filtering', () => {
     expect(file1Results.length).toBe(5);
     
     const file2Results = tasks.filter(task => applyFilter(task, 'path includes file2'));
-    expect(file2Results.length).toBe(1);
+    expect(file2Results.length).toBe(2);
   });
   
   test('queryTasks should apply multiple filters with AND logic', () => {

--- a/tests/task-parsing.test.ts
+++ b/tests/task-parsing.test.ts
@@ -7,6 +7,7 @@ const testTasks = [
   `- [ ] Task with #tag`,
   `- [ ] Task with high priority ⏫`,
   `- [ ] Task due today 🗓️ 2025-04-18`,
+  `- [ ] Task due today 📅 2025-04-18`, // The correct emoji for the ootb tasks plugin
   `- [x] Completed task`,
   `- [ ] Task in another file`
 ];

--- a/tests/test-vault/sample-tasks.md
+++ b/tests/test-vault/sample-tasks.md
@@ -7,6 +7,7 @@
 - [ ] Task with medium priority 🔼
 - [ ] Task with low priority 🔽
 - [ ] Task due today 🗓️ 2025-04-18
+- [ ] Task due today 📅 2025-04-18
 - [ ] Task scheduled for tomorrow ⏳ 2025-04-19
 - [ ] Task starts next week 🛫 2025-04-25
 - [ ] Task created yesterday ➕ 2025-04-17


### PR DESCRIPTION
Description

- Updated the regex for due date parsing to use the emoji used by obsidian tasks OOTB.
- `dueDateRegex = /[📅🗓️]\s?(\d{4}-\d{2}-\d{2})/;`
- Included the 'incorrect' emoji so that change did not break anything
- Added the correct date format to various tests
- Updated readme with correct emoji

Testing
- Tests pass 
- Tested mcp with claude - works correctly

